### PR TITLE
Fix Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 import PackageDescription
 
 let package = Package(
@@ -13,7 +13,7 @@ let package = Package(
     targets: [
         .target(
             name: "BlurUIKit",
-            path: "BlurUIKit/",
+            path: "BlurUIKit/"
         )
     ]
 )


### PR DESCRIPTION
I'm really excited about trying this out in a project I'm working on! However, there are two issues that prevent it from being used with SwiftPM:

 - The `.v14` iOS version was introduced with Swift tools version 5.3, so we need to bump that.
 - There's an erroneous trailing comma. These are allowed in collection literals but not in function calls.
