### PR TITLE
Fix for the blur effect when the direction is set to .right and .up (reversed)

### DIFF
--- a/BlurUIKit/Internal/GradientImageRenderer.swift
+++ b/BlurUIKit/Internal/GradientImageRenderer.swift
@@ -76,10 +76,10 @@ import UIKit
             bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
         ), let buffer = context.data else { return nil }
 
-        let pixels = buffer.assumingMemoryBound(to: UInt8.self)
+        let pixels: UnsafeMutablePointer<UInt8> = buffer.assumingMemoryBound(to: UInt8.self)
 
         // Clamp startLocation to valid range
-        let clampedStartLocation = min(max(startLocation, 0.0), 1.0)
+        let clampedStartLocation: CGFloat = min(max(startLocation, 0.0), 1.0)
 
         // Precompute reciprocals used in the gradient calculation
         let lengthReciprocal: CGFloat = length > 1 ? 1.0 / CGFloat(length - 1) : 0.0
@@ -91,29 +91,37 @@ import UIKit
             guard length > 1, clampedStartLocation > 0.0 else { return 0 }
             return min(Int(clampedStartLocation * CGFloat(length - 1)) + 1, length)
         }()
-
-        // Bulk-fill the constant region before the gradient (no per-pixel math needed)
-        if gradientStartPixel > 0 {
-            let constantAlpha: UInt8 = reversed ? 0 : 255
-            for i in stride(from: 0, to: gradientStartPixel * bytesPerPixel, by: bytesPerPixel) {
-                pixels[i] = 0
-                pixels[i + 1] = constantAlpha
-            }
+        
+        let gradientStart: Int = reversed ? 0 : gradientStartPixel
+        let gradientEnd: Int = reversed ? (length - gradientStartPixel) : length
+        let constantStart: Int = reversed ? gradientEnd : 0
+        let constantEnd: Int = reversed ? length : gradientStartPixel
+        
+        // Constant opaque region
+        for i in stride(from: constantStart * bytesPerPixel,
+                        to: constantEnd * bytesPerPixel,
+                        by: bytesPerPixel) {
+            pixels[i] = 0
+            pixels[i + 1] = 255
         }
-
-        // Generate the gradient transition for the remaining pixels
-        for i in gradientStartPixel..<length {
-            let normalizedPosition = CGFloat(i) * lengthReciprocal
-            let adjustedPosition = (normalizedPosition - clampedStartLocation) * gradientRangeReciprocal
-            let eased = smooth ? easeInOutSine(adjustedPosition) : adjustedPosition
-            let alpha = reversed ? eased : 1.0 - eased
-
-            let pixelIndex = i * bytesPerPixel
+        
+        // Gradient region
+        for i in gradientStart..<gradientEnd {
+            let normalizedPosition: CGFloat = CGFloat(i) * lengthReciprocal
+            
+            let adjustedPosition: CGFloat = reversed
+            ? normalizedPosition * gradientRangeReciprocal
+            : (normalizedPosition - clampedStartLocation) * gradientRangeReciprocal
+            
+            let eased: CGFloat = smooth ? easeInOutSine(adjustedPosition) : adjustedPosition
+            let alpha: CGFloat = reversed ? eased : 1.0 - eased
+            
+            let pixelIndex: Int = i * bytesPerPixel
             pixels[pixelIndex] = 0
             pixels[pixelIndex + 1] = UInt8(min(max(alpha * 255.0, 0.0), 255.0))
         }
 
-        guard let image = context.makeImage() else { return nil }
+        guard let image: CGImage = context.makeImage() else { return nil }
         cache.setObject(image, forKey: key)
         return image
     }


### PR DESCRIPTION
Hello @TimOliver,

When using `blurStartingInset` for my blurs, I noticed an issue in your library when using the `.right` and `.up` directions for the blur.

The blur doesn't seem correct for the `.right` and `.up` directions as you can see on this video using the original code:

https://github.com/user-attachments/assets/84268bcb-910c-47b3-ad7e-b3d46f5e1d3b

Here is another video with the code from this PR that fixes the issue:

https://github.com/user-attachments/assets/3675d246-6601-472b-ba50-9404fc00fa0b

Regards,
Axel

PS: please find below the SwiftUI code I used for the preview (not included in this PR).

<img width="2636" height="1866" alt="CleanShot 2026-04-04 at 09 23 15@2x" src="https://github.com/user-attachments/assets/acd15899-98e7-4d6d-bb57-67143b54ce88" />

```swift
//
//  SwiftUIExampleView.swift
//  BlurUIKitExample
//
//  Created by Tim Oliver on 10/2/2026.
//

import SwiftUI

struct SwiftUIExampleView: View {

    private let atlasImageSize = CGSize(width: 0.499, height: 0.249)
    private let fraction: CGFloat = 0.9
    
    var body: some View {
        GeometryReader { geometry in
            ScrollView {
                VStack(spacing: 16) {
                    ForEach(0..<8, id: \.self) { index in
                        atlasImage(index: index, width: geometry.size.width - 32)
                    }
                }
                .padding(.horizontal, 16)
                .padding(.top, geometry.safeAreaInsets.top + 8)
                .padding(.bottom, 16)
            }
            .ignoresSafeArea(edges: .top)
            .overlay(alignment: .top) {
                VariableBlur(direction: .down)
                    .blurStartingInset(.relative(fraction: fraction))
                    .ignoresSafeArea(edges: .top)
                    .frame(height: 100)
                    .border(.red)
            }
            .overlay {
                VStack {
                    VariableBlur(direction: .left)
                        .blurStartingInset(.relative(fraction: fraction))
                    
                    VariableBlur(direction: .right)
                        .blurStartingInset(.relative(fraction: fraction))
                }
                .frame(height: 200)
                .border(.red)
                .padding(.horizontal)
            }
            .overlay(alignment: .bottom) {
                    VariableBlur(direction: .up)
                        .blurStartingInset(.relative(fraction: fraction))
                        .ignoresSafeArea(edges: .bottom)
                        .frame(height: 100)
                        .border(.red)
            }
        }
    }

    @ViewBuilder
    private func atlasImage(index: Int, width: CGFloat) -> some View {
        let height = width / 1.777
        let fullWidth = width / atlasImageSize.width
        let fullHeight = height / atlasImageSize.height
        let originX = CGFloat(index % 2) * 0.5 * fullWidth
        let originY = CGFloat(index / 2) * 0.25 * fullHeight

        Image("AppleParkAtlas")
            .resizable()
            .frame(width: fullWidth, height: fullHeight)
            .offset(x: -originX, y: -originY)
            .frame(width: width, height: height, alignment: .topLeading)
            .clipShape(RoundedRectangle(cornerRadius: width * 0.1, style: .continuous))
    }
}

#Preview {
    SwiftUIExampleView()
}
```